### PR TITLE
Increase memory for gtfToCallingIntervals

### DIFF
--- a/gatk4-rna-best-practices.wdl
+++ b/gatk4-rna-best-practices.wdl
@@ -280,6 +280,7 @@ task gtfToCallingIntervals {
         docker: docker
         preemptible: true
         maxRetries: preemptible_count
+        memory: "~{ceil(size(gtf, 'GB') * 2)} GB"
     }
 }
 


### PR DESCRIPTION
`gtfToCallingIntervals` is running out of memory in the integration test, because the R script loads the whole gtf file into memory:

`gtf = read.table("${gtf}", sep="\t")`

This PR fixes this by setting the memory to twice the GTF file size.
