### PR TITLE
Increase memory of gtfToCallingIntervals task

### DIFF
--- a/gatk4-rna-best-practices.wdl
+++ b/gatk4-rna-best-practices.wdl
@@ -280,7 +280,7 @@ task gtfToCallingIntervals {
         docker: docker
         preemptible: true
         maxRetries: preemptible_count
-        memory: "~{ceil(size(gtf, 'GB') * 2)} GB"
+        memory: "4 GB"
     }
 }
 


### PR DESCRIPTION
Hard-codes memory to 4GB instead of dynamically calculating it.  Previously, a 2GB machine was being used by default.